### PR TITLE
Feat naive cache

### DIFF
--- a/menu_from_project/datamodel/project_config.py
+++ b/menu_from_project/datamodel/project_config.py
@@ -1,0 +1,84 @@
+# standard
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+# PyQGIS
+from qgis.core import (
+    QgsMapLayerType,
+    QgsWkbTypes,
+)
+
+
+@dataclass
+class MenuLayerConfig:
+    """Class to store configuration for layer menu creation"""
+
+    name: str
+    layer_id: str
+    filename: str
+    visible: bool
+    expanded: bool
+    embedded: str
+    is_spatial: bool
+    layer_type: Optional[QgsMapLayerType]
+    metadata_abstract: str
+    metadata_title: str
+    layer_notes: str
+    abstract: str
+    title: str
+    geometry_type: Optional[QgsWkbTypes.GeometryType] = None
+
+
+@dataclass
+class MenuGroupConfig:
+    """Class to store configuration for group menu creation"""
+
+    name: str
+    filename: str
+    childs: List[Any]  # List of Union[MenuLayerConfig,MenuGroupConfig]
+    embedded: bool
+
+    @classmethod
+    def from_json(cls, data):
+        childs = []
+        for child in data["childs"]:
+            if "childs" in child:
+                childs.append(cls.from_json(child))
+            else:
+                childs.append(MenuLayerConfig(**child))
+        res = cls(
+            name=data["name"],
+            filename=data["filename"],
+            embedded=data["embedded"],
+            childs=childs,
+        )
+        return res
+
+
+@dataclass
+class MenuProjectConfig:
+    """Class to store configuration for project menu creation"""
+
+    project_name: str
+    filename: str
+    uri: str
+    root_group: MenuGroupConfig
+
+    @classmethod
+    def from_json(cls, data):
+        """
+        Define User from json data
+
+        Args:
+            data: json data
+
+        Returns: User
+
+        """
+        res = cls(
+            filename=data["filename"],
+            uri=data["uri"],
+            project_name=data["project_name"],
+            root_group=MenuGroupConfig.from_json(data["root_group"]),
+        )
+        return res

--- a/menu_from_project/logic/cache_manager.py
+++ b/menu_from_project/logic/cache_manager.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 # project
-from menu_from_project.logic.project_read import MenuProjectConfig
+from menu_from_project.datamodel.project_config import MenuProjectConfig
 
 
 class CacheManager:
@@ -62,5 +62,18 @@ class CacheManager:
         """
         cache_path = Path(self.iface.userProfileManager().userProfile().folder())
         cache_path = cache_path / ".cache" / "menu-layer" / project["name"]
+        cache_path.mkdir(parents=True, exist_ok=True)
+        return cache_path
+
+    def get_project_download_dir(self, project: Dict[str, str]) -> Path:
+        """Get local project cache download directory
+
+        :param project: dict of information about the project
+        :type project: Dict[str, str]
+        :return: path to project cache directory
+        :rtype: Path
+        """
+        cache_path = self.get_project_cache_dir(project)
+        cache_path = cache_path / "downloads"
         cache_path.mkdir(parents=True, exist_ok=True)
         return cache_path

--- a/menu_from_project/logic/cache_manager.py
+++ b/menu_from_project/logic/cache_manager.py
@@ -1,0 +1,66 @@
+# standard
+from dataclasses import asdict
+import json
+from pathlib import Path
+from typing import Dict, Optional
+
+# project
+from menu_from_project.logic.project_read import MenuProjectConfig
+
+
+class CacheManager:
+    """Manager to get information from cached data
+
+    :param iface: QGIS iface
+    :type iface: QgsInterface
+    """
+
+    def __init__(self, iface) -> None:
+        self.iface = iface
+
+    def get_project_menu_config(
+        self, project: Dict[str, str]
+    ) -> Optional[MenuProjectConfig]:
+        """Get menu project configuration from cache for a project
+
+        :param project: dict of information about the project
+        :type project: Dict[str, str]
+        :return: menu project configuration from cache, None if no cache available
+        :rtype: Optional[MenuProjectConfig]
+        """
+        cache_path = self.get_project_cache_dir(project)
+        json_cache_path = cache_path / "project_config.json"
+        if json_cache_path.exists():
+            with open(json_cache_path, "r", encoding="UTF-8") as f:
+                data = json.load(f)
+                return MenuProjectConfig.from_json(data)
+        return None
+
+    def save_project_menu_config(
+        self, project: Dict[str, str], project_config: MenuProjectConfig
+    ) -> None:
+        """Save menu project configuration in cache
+
+        :param project: dict of information about the project
+        :type project: Dict[str, str]
+        :param project_config: menu project configuration
+        :type project_config: MenuProjectConfig
+        """
+        cache_path = self.get_project_cache_dir(project)
+        json_cache_path = cache_path / "project_config.json"
+
+        with open(json_cache_path, "w", encoding="UTF-8") as f:
+            json.dump(asdict(project_config), f, indent=4)
+
+    def get_project_cache_dir(self, project: Dict[str, str]) -> Path:
+        """Get local project cache directory
+
+        :param project: dict of information about the project
+        :type project: Dict[str, str]
+        :return: path to project cache directory
+        :rtype: Path
+        """
+        cache_path = Path(self.iface.userProfileManager().userProfile().folder())
+        cache_path = cache_path / ".cache" / "menu-layer" / project["name"]
+        cache_path.mkdir(parents=True, exist_ok=True)
+        return cache_path

--- a/menu_from_project/logic/project_read.py
+++ b/menu_from_project/logic/project_read.py
@@ -52,6 +52,22 @@ class MenuGroupConfig:
     childs: List[Any]  # List of Union[MenuLayerConfig,MenuGroupConfig]
     embedded: bool
 
+    @classmethod
+    def from_json(cls, data):
+        childs = []
+        for child in data["childs"]:
+            if "childs" in child:
+                childs.append(cls.from_json(child))
+            else:
+                childs.append(MenuLayerConfig(**child))
+        res = cls(
+            name=data["name"],
+            filename=data["filename"],
+            embedded=data["embedded"],
+            childs=childs,
+        )
+        return res
+
 
 @dataclass
 class MenuProjectConfig:
@@ -61,6 +77,25 @@ class MenuProjectConfig:
     filename: str
     uri: str
     root_group: MenuGroupConfig
+
+    @classmethod
+    def from_json(cls, data):
+        """
+        Define User from json data
+
+        Args:
+            data: json data
+
+        Returns: User
+
+        """
+        res = cls(
+            filename=data["filename"],
+            uri=data["uri"],
+            project_name=data["project_name"],
+            root_group=MenuGroupConfig.from_json(data["root_group"]),
+        )
+        return res
 
 
 def get_embedded_project_from_layer_tree(

--- a/menu_from_project/logic/project_read.py
+++ b/menu_from_project/logic/project_read.py
@@ -1,7 +1,6 @@
 # standard
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 # PyQGIS
 from qgis.PyQt import QtXml
@@ -21,81 +20,11 @@ from menu_from_project.logic.qgs_manager import (
     create_map_layer_dict,
     is_absolute,
 )
-
-
-@dataclass
-class MenuLayerConfig:
-    """Class to store configuration for layer menu creation"""
-
-    name: str
-    layer_id: str
-    filename: str
-    visible: bool
-    expanded: bool
-    embedded: str
-    is_spatial: bool
-    layer_type: Optional[QgsMapLayerType]
-    metadata_abstract: str
-    metadata_title: str
-    layer_notes: str
-    abstract: str
-    title: str
-    geometry_type: Optional[QgsWkbTypes.GeometryType] = None
-
-
-@dataclass
-class MenuGroupConfig:
-    """Class to store configuration for group menu creation"""
-
-    name: str
-    filename: str
-    childs: List[Any]  # List of Union[MenuLayerConfig,MenuGroupConfig]
-    embedded: bool
-
-    @classmethod
-    def from_json(cls, data):
-        childs = []
-        for child in data["childs"]:
-            if "childs" in child:
-                childs.append(cls.from_json(child))
-            else:
-                childs.append(MenuLayerConfig(**child))
-        res = cls(
-            name=data["name"],
-            filename=data["filename"],
-            embedded=data["embedded"],
-            childs=childs,
-        )
-        return res
-
-
-@dataclass
-class MenuProjectConfig:
-    """Class to store configuration for project menu creation"""
-
-    project_name: str
-    filename: str
-    uri: str
-    root_group: MenuGroupConfig
-
-    @classmethod
-    def from_json(cls, data):
-        """
-        Define User from json data
-
-        Args:
-            data: json data
-
-        Returns: User
-
-        """
-        res = cls(
-            filename=data["filename"],
-            uri=data["uri"],
-            project_name=data["project_name"],
-            root_group=MenuGroupConfig.from_json(data["root_group"]),
-        )
-        return res
+from menu_from_project.datamodel.project_config import (
+    MenuProjectConfig,
+    MenuGroupConfig,
+    MenuLayerConfig,
+)
 
 
 def get_embedded_project_from_layer_tree(

--- a/menu_from_project/logic/project_read.py
+++ b/menu_from_project/logic/project_read.py
@@ -357,6 +357,7 @@ def get_project_menu_config(
 
     # Get path to QgsProject file, local / downloaded / from postgres database
     uri = project["file"]
+    qgs_dom_manager.set_project(project)
     doc, filename = qgs_dom_manager.getQgsDoc(uri)
 
     # Define project name
@@ -373,7 +374,7 @@ def get_project_menu_config(
             # Create dict of maplayer nodes
             maplayer_dict = create_map_layer_dict(doc)
             # Parse node for group and layers
-            return MenuProjectConfig(
+            menu_project_config = MenuProjectConfig(
                 project_name=name,
                 filename=filename,
                 uri=uri,
@@ -385,4 +386,7 @@ def get_project_menu_config(
                     absolute_project=is_absolute(doc),
                 ),
             )
+
+            qgs_dom_manager.set_project(None)
+            return menu_project_config
     return None

--- a/menu_from_project/logic/qgs_manager.py
+++ b/menu_from_project/logic/qgs_manager.py
@@ -125,7 +125,7 @@ def get_project_title(doc: QtXml.QDomDocument) -> str:
 
 
 @lru_cache()
-def read_from_file(uri: str) -> Tuple[QtXml.QDomDocument, str]:
+def read_from_file(uri: str) -> QtXml.QDomDocument:
     """Read a QGIS project (.qgs and .qgz) from a file path and returns d
 
     :param uri: path to the file
@@ -134,7 +134,7 @@ def read_from_file(uri: str) -> Tuple[QtXml.QDomDocument, str]:
     :return: a tuple with XML document and the filepath.
     :rtype: Tuple[QtXml.QDomDocument, str]
     """
-    doc, project_path = QtXml.QDomDocument(), None
+    doc = QtXml.QDomDocument()
     file = QFile(uri)
     if (
         file.exists()
@@ -142,7 +142,6 @@ def read_from_file(uri: str) -> Tuple[QtXml.QDomDocument, str]:
         and QFileInfo(file).suffix() == "qgs"
     ):
         doc.setContent(file)
-        project_path = uri
 
     elif file.exists() and (QFileInfo(file).suffix() == "qgz"):
         temporary_unzip = QTemporaryDir()
@@ -156,7 +155,7 @@ def read_from_file(uri: str) -> Tuple[QtXml.QDomDocument, str]:
         if xml.open(QIODevice.ReadOnly | QIODevice.Text):
             doc.setContent(xml)
 
-    return doc, project_path
+    return doc
 
 
 def read_from_database(uri: str, project_registry) -> Tuple[QtXml.QDomDocument, str]:
@@ -229,7 +228,7 @@ def read_from_http(uri: str, cache_folder: Path):
     project_download.startDownload()
     loop.exec_()
 
-    return read_from_file(str(cached_filepath))
+    return read_from_file(str(cached_filepath)), str(cached_filepath)
 
 
 class QgsDomManager:
@@ -263,7 +262,8 @@ class QgsDomManager:
             return self.docs[uri], uri
 
         if qgs_storage_type == "file":
-            doc, project_path = read_from_file(uri)
+            doc = read_from_file(uri)
+            project_path = uri
         elif qgs_storage_type == "database":
             doc, project_path = read_from_database(uri, self.project_registry)
         elif qgs_storage_type == "http":

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -23,6 +23,7 @@ from dataclasses import asdict
 import json
 import logging
 import os
+from pathlib import Path
 from typing import Dict, Optional, List, Tuple, Any
 
 # PyQGIS

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -55,12 +55,13 @@ from menu_from_project.logic.tools import (
     icon_per_layer_type,
 )
 from menu_from_project.ui.menu_conf_dlg import MenuConfDialog  # noqa: F4 I001
-from menu_from_project.logic.project_read import (
+from menu_from_project.datamodel.project_config import (
     MenuGroupConfig,
     MenuLayerConfig,
     MenuProjectConfig,
-    get_project_menu_config,
 )
+
+from menu_from_project.logic.project_read import get_project_menu_config
 
 # ############################################################################
 # ########## Globals ###############

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -19,6 +19,8 @@ email                : xavier.culos@eau-adour-garonne.fr
 """
 
 # Standard library
+from dataclasses import asdict
+import json
 import logging
 import os
 from typing import Dict, Optional, List, Tuple, Any
@@ -199,9 +201,22 @@ class MenuFromProject:
         nb_projects = len(settings.projects)
         for i, project in enumerate(settings.projects):
             task.setProgress(i * 100.0 / nb_projects)
+            # Get path to project menu config file
+            cache_path = Path(self.iface.userProfileManager().userProfile().folder())
+            cache_path = cache_path / ".cache" / "menu-layer" / project["name"]
+            cache_path.mkdir(parents=True, exist_ok=True)
+            json_cache_path = cache_path / "project_config.json"
+            if json_cache_path.exists():
+                with open(json_cache_path, "r", encoding="UTF-8") as f:
+                    data = json.load(f)
+                    result.append((project, MenuProjectConfig.from_json(data)))
+                continue
 
             # Create project menu configuration from QgsProject
             project_config = get_project_menu_config(project, self.qgs_dom_manager)
+
+            with open(json_cache_path, "w", encoding="UTF-8") as f:
+                json.dump(asdict(project_config), f, indent=4)
 
             result.append((project, project_config))
         return result

--- a/tests/qgis/test_project_read.py
+++ b/tests/qgis/test_project_read.py
@@ -36,30 +36,28 @@ class TestProjectMenuConfig(unittest.TestCase):
         """Read a sample project and check returned informations"""
 
         qgs_dom_manager = QgsDomManager()
-
+        filename = str(Path(__file__).parent / ".." / "projets" / "aeag-tiny.qgz")
         project = {
-            "file": str(Path(__file__).parent / ".." / "projets" / "aeag-tiny.qgz"),
+            "file": filename,
             "name": "test_import",
         }
 
         result = get_project_menu_config(
             project=project, qgs_dom_manager=qgs_dom_manager
         )
-        # Can't define filename because temp file is used
-        tmp_filename = result.filename
 
         expected = MenuProjectConfig(
             project_name="test_import",
-            filename=tmp_filename,
+            filename=filename,
             uri=project["file"],
             root_group=MenuGroupConfig(
                 name="",
-                filename=tmp_filename,
+                filename=filename,
                 childs=[
                     MenuLayerConfig(
                         name="Sites de mesure qualit\u00e9 (cours d'eau)",
                         layer_id="L8150cde67501427eade1e787479c2f70",
-                        filename=tmp_filename,
+                        filename=filename,
                         visible=True,
                         expanded=True,
                         embedded=False,
@@ -75,7 +73,7 @@ class TestProjectMenuConfig(unittest.TestCase):
                     MenuLayerConfig(
                         name="Cours d'eau",
                         layer_id="L35ecffe715c74f15bec52340aa3c9e3f",
-                        filename=tmp_filename,
+                        filename=filename,
                         visible=True,
                         expanded=False,
                         embedded=False,
@@ -91,7 +89,7 @@ class TestProjectMenuConfig(unittest.TestCase):
                     MenuLayerConfig(
                         name="Bassin Hydrographique",
                         layer_id="Lbd28399787e349488c2f7bb0298b370d",
-                        filename=tmp_filename,
+                        filename=filename,
                         visible=True,
                         expanded=False,
                         embedded=False,

--- a/tests/qgis/test_project_read.py
+++ b/tests/qgis/test_project_read.py
@@ -17,12 +17,12 @@ from qgis.core import QgsMapLayerType, QgsWkbTypes
 
 from pathlib import Path
 
-from menu_from_project.logic.project_read import (
+from menu_from_project.datamodel.project_config import (
     MenuProjectConfig,
     MenuGroupConfig,
     MenuLayerConfig,
-    get_project_menu_config,
 )
+from menu_from_project.logic.project_read import get_project_menu_config
 from menu_from_project.logic.qgs_manager import QgsDomManager
 
 


### PR DESCRIPTION
First implementation of naive cache in profile folder.

In the cache folder for each project we are saving:
- a `project_config.json` file that contains the result of QGIS project parsing in json format
- the downloaded QGIS project for http and postgres project

When loading project, if the file is available it's always used. To invalidate cache we must remove manualy cache folder content.

## Changes

- move all class related to project configuration in `menu_from_project/datamodel/project_config.py`. This avoid circular dependency.
- add json read/write for project configuration classes
- create a new class `CacheManager` to get project configuration from cache and store result in cache folder. Also used to get download folder for a project.
- update `QgsDomManager` to be able to define a project, needed to download http and postgres QGIS project in specific download folder for each project

## Fixes

- for embedded properties of group and layer, we were also looking in all children. We are now limiting research to `customproperties` tag

